### PR TITLE
MODI value is inccorect

### DIFF
--- a/funcs/general.py
+++ b/funcs/general.py
@@ -88,6 +88,6 @@ def modi(df , outcome , descriptor = "maccs"):
         outcomeList.append(dm2[outcome][dm2.index == sel_index[0]].to_list()[0])
     dm2["nn_outcome"] = outcomeList
     tot_agree = dm2[dm2[outcome] == dm2["nn_outcome"]].shape[0]
-    tot = dm2[dm2[outcome] == dm2["nn_outcome"]].shape[1]
+    tot = dm.shape[0]
     modi = tot_agree/tot
     return modi 


### PR DESCRIPTION
Hello,

I was using your modi code and saw that I was getting values of 0.04 for really small (400 compounds) dataset. That seemed impossible to me so I looked at the code and saw an issue with this line:
`tot = dm2[dm2[outcome] == dm2["nn_outcome"]].shape[1]`
This is supposed to be the total number of compounds in the dataset, but it actually the total number of columns in the descriptor dataframe merged with the pairwise distance dataframe (so for morgan its 2048 + num_compounds). For large datasets its hard to spot the difference as it will approach the true value, but for small datasets it will result in incorrect very small modis

so the really number of total compounds is just the number of row of dm (or df) so it can be fixed with tot=dm.shape[0]